### PR TITLE
Bugfix providers even further

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ MtbMap()
 NASAGIBS()
 NASAGIBSTimeseries()
 NLS()
+nlmaps()
 OPNVKarte()
 OneMapSG()
 OpenAIP()
@@ -58,7 +59,6 @@ Thunderforest()
 TomTom()
 USGS()
 WaymarkedTrails()
-nlmaps()
 ```
 
 Some providers will need an `apikey`, `accesstoken`, `app_code` or `subscriptionkey` keyword if registration

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ MapTiler()
 MapTilesAPI()
 MtbMap()
 NASAGIBS()
+NASAGIBSTimeseries()
 NLS()
 OPNVKarte()
 OneMapSG()
@@ -54,16 +55,24 @@ Stadia()
 Stamen()
 SwissFederalGeoportal()
 Thunderforest()
-TileProviders()
 TomTom()
 USGS()
 WaymarkedTrails()
-geturl()
 nlmaps()
 ```
 
-Some providers will need an `apikey` or `accestoken` keyword if registration
+Some providers will need an `apikey`, `accesstoken`, `app_code` or `subscriptionkey` keyword if registration
 is required to use the dataset. See the docs for the function.
+
+To get the specific urls from a `Provider` use:
+```julia
+TileProviders.geturl(provider, x, y, z)
+```
+
+Get a dictionary of all `Providers` and their `variants` with:
+```julia
+TileProviders.list_providers()
+```
 
 Providers are retrieved from leaflet via geopandas repository:
 https://raw.githubusercontent.com/geopandas/xyzservices/main/provider_sources/leaflet-providers-parsed.json

--- a/src/nasagibs.jl
+++ b/src/nasagibs.jl
@@ -768,33 +768,46 @@ const _NASAGIBS_DICT = begin
 end
 
 """
-    NASAGIBS(variant::Symbol; date="2020-01-01")
+    NASAGIBSTimeseries(variant::Symbol; date="2020-01-01")
 
 [`Provider`](@ref) for A huge range of layers from the NASA Global Imagery Browse Services (GIBS).
 
-Some common layers like `:BlueMarble_****` variants and `:VIIRS_CityLights_2012`, and masks/coasatlines 
-do not require `date`. Most others layers do, with a default of 2020-01-01 used.
-`date` can be a "yyyy-mm-dd" formatted `String` or any `Dates.TimeType` like `Date` or `DateTime`.
-It must correspond to an available date for the dataset - if not empty tiles will be returned.
+# Arguments
+
+- `variant`: variant of layer, with a default of `:VIIRS_CityLights_2012`. See below for a full list of available `variants`.
+
+## Keywords
+
+- `date`: date of the requested dataset. If omitted, a default of 2020-01-01 will be used. Can be a "yyyy-mm-dd" formatted `String` or any `Dates.TimeType` like `Date` or `DateTime`. It must correspond to an available date for the dataset - if not empty tiles will be returned.
 
 Note that the default 2020 date may not correspond to an available date for a specific layer. 
-See the [NASA GIBS documentation](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog)
-for the available dates.
+See the [NASA GIBS documentation](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog) for the available dates.
+
+These following layers do not require a `date`: 
+- the `:BlueMarble_****` variants
+- `:Coastlines`
+- `:MODIS_Water_Mask`
+- `:Reference_Features`
+- `:Reference_Labels`
+- `:SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange` 
+- `:VIIRS_CityLights_2012`
 
 # Example
 
 ```julia
-provider = Leaflet.NASAGIBS(:VIIRS_CityLights_2012)
-# provider = Leaflet.NASAGIBS(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07))
+provider = NASAGIBSTimeseries()
+# provider = NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07))
 m = Leaflet.Map(; provider, zoom=3, height=1000);
 # Open as a Blink.jl app
 w = Blink.Window()
 body!(w, m)
 ```
 
+# Available Variants
+
 $(_variant_list(_NASAGIBS_KEYS))
 """
-function NASAGIBSTimeseries(variant::Symbol=:reflectance; date="2020-01-01")
+function NASAGIBSTimeseries(variant::Symbol=:VIIRS_CityLights_2012; date="2020-01-01")
     _checkin(variant, _NASAGIBS_DICT)
     if date isa Dates.TimeType
         date = Dates.format(date, "yyyy-mm-dd")
@@ -815,4 +828,4 @@ function NASAGIBSTimeseries(variant::Symbol=:reflectance; date="2020-01-01")
     return provider
 end
 
-
+PROVIDER_DICT[NASAGIBSTimeseries] = _NASAGIBS_KEYS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,45 +4,49 @@ using Dates
 
 @testset "TileProviders.jl run" begin
     providers = (
-        CyclOSM(),
-        USGS(),
-        Stadia(),
-        OPNVKarte(),
-        FreeMapSK(),
-        HikeBike(),
-        NLS(),
-        OpenSeaMap(),
-        WaymarkedTrails(),
-        MtbMap(),
-        CartoDB(),
-        OpenRailwayMap(),
-        NASAGIBS(),
-        OneMapSG(),
-        Stamen(),
-        JusticeMap(),
-        SafeCast(),
-        MapTiler(),
-        OpenFireMap(),
+        # from leaflet-providers-parsed.json
         OpenStreetMap(),
-        Google(),
-        nlmaps(),
-        SwissFederalGeoportal(),
+        MapTilesAPI(; apikey="some_key"),
+        OpenSeaMap(),
+        OPNVKarte(),
         OpenTopoMap(),
-        OpenSnowMap(),
-        OpenAIP(),
-        Esri(),
-        BasemapAT(),
-        TomTom(; apikey="some_apikey"),
+        OpenRailwayMap(),
+        OpenFireMap(),
+        SafeCast(),
+        Stadia(),
         Thunderforest(; apikey="some_apikey"),
+        CyclOSM(),
         Jawg(; accesstoken="some_token"),
-        GeoportailFrance(; apikey="some_apikey"),
         MapBox(; accesstoken="some_token"),
-        Jawg(; accesstoken="some_token"),
-        Thunderforest(; apikey="some_apikey"),
+        MapTiler(),
+        Stamen(),
+        TomTom(; apikey="some_apikey"),
+        Esri(),
+        OpenWeatherMap(; apikey="some_apikey"),
         HERE(; app_code="some_app_code"),
         HEREv3(; apikey="some_apikey"),
-        TileProviders.NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07)),
-        TileProviders.Provider("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png") ,
+        FreeMapSK(),
+        MtbMap(),
+        CartoDB(),
+        HikeBike(),
+        BasemapAT(),
+        nlmaps(),
+        NASAGIBS(),
+        NLS(),
+        JusticeMap(),
+        GeoportailFrance(; apikey="some_apikey"),
+        OneMapSG(),
+        USGS(),
+        WaymarkedTrails(),
+        OpenAIP(),
+        OpenSnowMap(),
+        AzureMaps(; subscriptionkey="some_subscriptionkey"),
+        SwissFederalGeoportal(),
+
+        # Google, NASAGIBSTimeseries, general Provider
+        Google(),
+        NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07)),
+        Provider("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png") ,
     )
 
     for provider in providers
@@ -52,20 +56,21 @@ using Dates
         @test !occursin("}", url)
     end
 
-    provider = TileProviders.OpenStreetMap()
+    provider = OpenStreetMap()
     @test TileProviders.geturl(provider, 1, 2, 3) == "https://tile.openstreetmap.org/3/1/2.png"
-    provider = TileProviders.NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07))
+    provider = NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07))
     @test TileProviders.geturl(provider, 1, 2, 3) == "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/AMSRE_Brightness_Temp_89H_Day/default/2010-05-07/GoogleMapsCompatible_Level6/3/2/1.png"
 
-    @test_throws UndefKeywordError MapBox()
     @test_throws UndefKeywordError MapTilesAPI()
-    @test_throws UndefKeywordError HEREv3()
-    @test_throws UndefKeywordError HERE()
-    @test_throws UndefKeywordError OpenWeatherMap()
-    @test_throws UndefKeywordError AzureMaps()
     @test_throws UndefKeywordError Thunderforest()
     @test_throws UndefKeywordError Jawg()
+    @test_throws UndefKeywordError MapBox()
+    @test_throws UndefKeywordError TomTom()
+    @test_throws UndefKeywordError OpenWeatherMap()
+    @test_throws UndefKeywordError HERE()
+    @test_throws UndefKeywordError HEREv3()
     @test_throws UndefKeywordError GeoportailFrance()
+    @test_throws UndefKeywordError AzureMaps()
 
     TileProviders.list_providers()
 end


### PR DESCRIPTION
I fixed a bunch of problems and inconsistencies I came across when playing around with different tile providers. Here they are:
In the NASAGIBS file:
- Empty constructor for the `NASAGIBSTimeseries` failed due to the default keyword not being in the list of valid ones.
- Fixed and extended docstring of `NASAGIBSTimeseries` (still, somehow printing about 800 lines of variantlist makes the docstring basically useless in the REPL...)
- Added `NASAGIBSTimeseries` to `PROVIDER_DICT`

in the providers file:
- set `keyword` in the docstring to always be lowercase, since the keywords of the functions are as well
- moved check for existence of `variant` one line up, otherwise we get the `keyword` of the `Provider` to show up as a possible `variant` in the error message
- split creation of functions with default arguments and keyword arguments in two steps, because there seems to be some strange behaviour with the `methods` function (see https://github.com/JuliaLang/julia/issues/49028)

Tests:
- reshuffled tests a bit to contain all `Providers` in the order they appear in the `json`

Readme:
- fixed the readme to show all provider functions and how to get urls as well as the `PROVIDER_DICT`