### PR TITLE
Fix handling of apikey keyword for services with variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
-.vscode/settings.json

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -86,7 +86,7 @@ function geturl(provider::AbstractProvider, x::Integer, y::Integer, z::Integer)
             push!(replacements, string('{', key, '}') => string(val))
         end
     end
-    if VERSION < v"1.7"
+    @static if VERSION < v"1.7"
         result_url = url(provider)
         for replacement in replacements
             result_url = replace(result_url, replacement)

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -86,7 +86,15 @@ function geturl(provider::AbstractProvider, x::Integer, y::Integer, z::Integer)
             push!(replacements, string('{', key, '}') => string(val))
         end
     end
-    return replace(url(provider), replacements...)
+    if VERSION < v"1.7"
+        result_url = url(provider)
+        for replacement in replacements
+            result_url = replace(result_url, replacement)
+        end
+        return result_url
+    else
+        return replace(url(provider), replacements...)
+    end
 end
 
 function _access(d)

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -142,10 +142,10 @@ let
             keyword = _access(first(values(v)))
             keyword_docs = _keyword_docs(keyword, name)
             variants = keys(v)
-            keyword_expr = isnothing(keyword) ? nothing : :(options[$(QuoteNode(keyword))] = $(Symbol(lowercase(string(keyword)))))
+            keyword_expr = isnothing(keyword) ? nothing : :(options[variant][$(QuoteNode(keyword))] = $(Symbol(lowercase(string(keyword)))))
             contents = quote
                 provider_name = $name
-                options = Dict($v)
+                options = copy($v)
                 variant in keys(options) || throw(ArgumentError("$provider_name variant must be from $(keys(options)), got $variant"))
                 $keyword_expr
                 Provider(options[variant][:url], options[variant])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,8 @@ using Dates
     @test TileProviders.geturl(provider, 1, 2, 3) == "https://tile.openstreetmap.org/3/1/2.png"
     provider = NASAGIBSTimeseries(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07))
     @test TileProviders.geturl(provider, 1, 2, 3) == "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/AMSRE_Brightness_Temp_89H_Day/default/2010-05-07/GoogleMapsCompatible_Level6/3/2/1.png"
+    provider = GeoportailFrance(;apikey = "cartes") # Default variant corresponds to Plan IGN service "https://geoservices.ign.fr/services-web-experts-cartes"
+    @test TileProviders.geturl(provider, 1, 2, 3) == "https://wxs.ign.fr/cartes/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&TILEMATRIX=3&TILEROW=2&TILECOL=1"
 
     @test_throws UndefKeywordError MapTilesAPI()
     @test_throws UndefKeywordError Thunderforest()


### PR DESCRIPTION
I had an issue with `GeoPortailFrance` not taking in account the `apikey` keyword.

Now it works. I had to convert the `options` `JSON3.object` to `Dict` via `copy`

I added a test on the URL returned by `geturl`