### PR TITLE
Updated to the latest version of leaflet-providers-parsed.json

### DIFF
--- a/src/leaflet-providers-parsed.json
+++ b/src/leaflet-providers-parsed.json
@@ -8,7 +8,7 @@
             "name": "OpenStreetMap.Mapnik"
         },
         "DE": {
-            "url": "https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png",
+            "url": "https://tile.openstreetmap.de/{z}/{x}/{y}.png",
             "max_zoom": 18,
             "html_attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) OpenStreetMap contributors",
@@ -135,32 +135,144 @@
     },
     "Stadia": {
         "AlidadeSmooth": {
-            "url": "https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png",
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
             "max_zoom": 20,
-            "html_attribution": "&copy; <a href=\"https://stadiamaps.com/\">Stadia Maps</a>, &copy; <a href=\"https://openmaptiles.org/\">OpenMapTiles</a> &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors",
-            "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "alidade_smooth",
+            "ext": "png",
             "name": "Stadia.AlidadeSmooth"
         },
         "AlidadeSmoothDark": {
-            "url": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png",
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
             "max_zoom": 20,
-            "html_attribution": "&copy; <a href=\"https://stadiamaps.com/\">Stadia Maps</a>, &copy; <a href=\"https://openmaptiles.org/\">OpenMapTiles</a> &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors",
-            "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "alidade_smooth_dark",
+            "ext": "png",
             "name": "Stadia.AlidadeSmoothDark"
         },
         "OSMBright": {
-            "url": "https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}{r}.png",
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
             "max_zoom": 20,
-            "html_attribution": "&copy; <a href=\"https://stadiamaps.com/\">Stadia Maps</a>, &copy; <a href=\"https://openmaptiles.org/\">OpenMapTiles</a> &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors",
-            "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "osm_bright",
+            "ext": "png",
             "name": "Stadia.OSMBright"
         },
         "Outdoors": {
-            "url": "https://tiles.stadiamaps.com/tiles/outdoors/{z}/{x}/{y}{r}.png",
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
             "max_zoom": 20,
-            "html_attribution": "&copy; <a href=\"https://stadiamaps.com/\">Stadia Maps</a>, &copy; <a href=\"https://openmaptiles.org/\">OpenMapTiles</a> &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors",
-            "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "outdoors",
+            "ext": "png",
             "name": "Stadia.Outdoors"
+        },
+        "StamenToner": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_toner",
+            "ext": "png",
+            "name": "Stadia.StamenToner"
+        },
+        "StamenTonerBackground": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_toner_background",
+            "ext": "png",
+            "name": "Stadia.StamenTonerBackground"
+        },
+        "StamenTonerLines": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_toner_lines",
+            "ext": "png",
+            "name": "Stadia.StamenTonerLines"
+        },
+        "StamenTonerLabels": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_toner_labels",
+            "ext": "png",
+            "name": "Stadia.StamenTonerLabels"
+        },
+        "StamenTonerLite": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 20,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_toner_lite",
+            "ext": "png",
+            "name": "Stadia.StamenTonerLite"
+        },
+        "StamenWatercolor": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}.{ext}",
+            "min_zoom": 1,
+            "max_zoom": 16,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_watercolor",
+            "ext": "jpg",
+            "name": "Stadia.StamenWatercolor"
+        },
+        "StamenTerrain": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_terrain",
+            "ext": "png",
+            "name": "Stadia.StamenTerrain"
+        },
+        "StamenTerrainBackground": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_terrain_background",
+            "ext": "png",
+            "name": "Stadia.StamenTerrainBackground"
+        },
+        "StamenTerrainLabels": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_terrain_labels",
+            "ext": "png",
+            "name": "Stadia.StamenTerrainLabels"
+        },
+        "StamenTerrainLines": {
+            "url": "https://tiles.stadiamaps.com/tiles/{variant}/{z}/{x}/{y}{r}.{ext}",
+            "min_zoom": 0,
+            "max_zoom": 18,
+            "html_attribution": "&copy; <a href=\"https://www.stadiamaps.com/\" target=\"_blank\">Stadia Maps</a> &copy; <a href=\"https://www.stamen.com/\" target=\"_blank\">Stamen Design</a> &copy; <a href=\"https://openmaptiles.org/\" target=\"_blank\">OpenMapTiles</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) Stadia Maps (C) Stamen Design (C) OpenMapTiles (C) OpenStreetMap contributors",
+            "variant": "stamen_terrain_lines",
+            "ext": "png",
+            "name": "Stadia.StamenTerrainLines"
         }
     },
     "Thunderforest": {
@@ -246,6 +358,22 @@
             "name": "Thunderforest.Neighbourhood"
         }
     },
+    "BaseMapDE": {
+        "Color": {
+            "url": "https://sgx.geodatenzentrum.de/wmts_basemapde/tile/1.0.0/{variant}/default/GLOBAL_WEBMERCATOR/{z}/{y}/{x}.png",
+            "html_attribution": "Map data: &copy; <a href=\"http://www.govdata.de/dl-de/by-2-0\">dl-de/by-2-0</a>",
+            "attribution": "Map data: (C) dl-de/by-2-0",
+            "variant": "de_basemapde_web_raster_farbe",
+            "name": "BaseMapDE.Color"
+        },
+        "Grey": {
+            "url": "https://sgx.geodatenzentrum.de/wmts_basemapde/tile/1.0.0/{variant}/default/GLOBAL_WEBMERCATOR/{z}/{y}/{x}.png",
+            "html_attribution": "Map data: &copy; <a href=\"http://www.govdata.de/dl-de/by-2-0\">dl-de/by-2-0</a>",
+            "attribution": "Map data: (C) dl-de/by-2-0",
+            "variant": "de_basemapde_web_raster_grau",
+            "name": "BaseMapDE.Grey"
+        }
+    },
     "CyclOSM": {
         "url": "https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png",
         "max_zoom": 20,
@@ -255,67 +383,71 @@
     },
     "Jawg": {
         "Streets": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
             "variant": "jawg-streets",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Streets"
         },
         "Terrain": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
             "variant": "jawg-terrain",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Terrain"
         },
-        "Sunny": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+        "Lagoon": {
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
+            "variant": "jawg-lagoon",
+            "accessToken": "<insert your access token here>",
+            "name": "Jawg.Lagoon"
+        },
+        "Sunny": {
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
+            "min_zoom": 0,
+            "max_zoom": 22,
             "variant": "jawg-sunny",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Sunny"
         },
         "Dark": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
             "variant": "jawg-dark",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Dark"
         },
         "Light": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
             "variant": "jawg-light",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Light"
         },
         "Matrix": {
-            "url": "https://{s}.tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
-            "html_attribution": "<a href=\"http://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+            "url": "https://tile.jawg.io/{variant}/{z}/{x}/{y}{r}.png?access-token={accessToken}",
+            "html_attribution": "<a href=\"https://jawg.io\" title=\"Tiles Courtesy of Jawg Maps\" target=\"_blank\">&copy; <b>Jawg</b>Maps</a> &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
             "attribution": "(C) **Jawg** Maps (C) OpenStreetMap contributors",
             "min_zoom": 0,
             "max_zoom": 22,
-            "subdomains": "abcd",
             "variant": "jawg-matrix",
             "accessToken": "<insert your access token here>",
             "name": "Jawg.Matrix"
@@ -449,161 +581,45 @@
             "min_zoom": 0,
             "max_zoom": 21,
             "name": "MapTiler.Voyager"
-        }
-    },
-    "Stamen": {
-        "Toner": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner",
+        },
+        "Ocean": {
+            "url": "https://api.maptiler.com/maps/{variant}/{z}/{x}/{y}{r}.{ext}?key={key}",
+            "html_attribution": "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+            "attribution": "(C) MapTiler (C) OpenStreetMap contributors",
+            "variant": "ocean",
             "ext": "png",
-            "name": "Stamen.Toner"
-        },
-        "TonerBackground": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
+            "key": "<insert your MapTiler Cloud API key here>",
+            "tileSize": 512,
+            "zoomOffset": -1,
             "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner-background",
+            "max_zoom": 21,
+            "name": "MapTiler.Ocean"
+        },
+        "Backdrop": {
+            "url": "https://api.maptiler.com/maps/{variant}/{z}/{x}/{y}{r}.{ext}?key={key}",
+            "html_attribution": "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+            "attribution": "(C) MapTiler (C) OpenStreetMap contributors",
+            "variant": "backdrop",
             "ext": "png",
-            "name": "Stamen.TonerBackground"
-        },
-        "TonerHybrid": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
+            "key": "<insert your MapTiler Cloud API key here>",
+            "tileSize": 512,
+            "zoomOffset": -1,
             "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner-hybrid",
+            "max_zoom": 21,
+            "name": "MapTiler.Backdrop"
+        },
+        "Dataviz": {
+            "url": "https://api.maptiler.com/maps/{variant}/{z}/{x}/{y}{r}.{ext}?key={key}",
+            "html_attribution": "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+            "attribution": "(C) MapTiler (C) OpenStreetMap contributors",
+            "variant": "dataviz",
             "ext": "png",
-            "name": "Stamen.TonerHybrid"
-        },
-        "TonerLines": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
+            "key": "<insert your MapTiler Cloud API key here>",
+            "tileSize": 512,
+            "zoomOffset": -1,
             "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner-lines",
-            "ext": "png",
-            "name": "Stamen.TonerLines"
-        },
-        "TonerLabels": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner-labels",
-            "ext": "png",
-            "name": "Stamen.TonerLabels"
-        },
-        "TonerLite": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toner-lite",
-            "ext": "png",
-            "name": "Stamen.TonerLite"
-        },
-        "Watercolor": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 1,
-            "max_zoom": 16,
-            "variant": "watercolor",
-            "ext": "jpg",
-            "name": "Stamen.Watercolor"
-        },
-        "Terrain": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 18,
-            "variant": "terrain",
-            "ext": "png",
-            "name": "Stamen.Terrain"
-        },
-        "TerrainBackground": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 18,
-            "variant": "terrain-background",
-            "ext": "png",
-            "name": "Stamen.TerrainBackground"
-        },
-        "TerrainLabels": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 18,
-            "variant": "terrain-labels",
-            "ext": "png",
-            "name": "Stamen.TerrainLabels"
-        },
-        "TopOSMRelief": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toposm-color-relief",
-            "ext": "jpg",
-            "bounds": [
-                [
-                    22,
-                    -132
-                ],
-                [
-                    51,
-                    -56
-                ]
-            ],
-            "name": "Stamen.TopOSMRelief"
-        },
-        "TopOSMFeatures": {
-            "url": "https://stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}{r}.{ext}",
-            "html_attribution": "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a> &mdash; Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
-            "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
-            "subdomains": "abcd",
-            "min_zoom": 0,
-            "max_zoom": 20,
-            "variant": "toposm-features",
-            "ext": "png",
-            "bounds": [
-                [
-                    22,
-                    -132
-                ],
-                [
-                    51,
-                    -56
-                ]
-            ],
-            "opacity": 0.9,
-            "name": "Stamen.TopOSMFeatures"
+            "max_zoom": 21,
+            "name": "MapTiler.Dataviz"
         }
     },
     "TomTom": {
@@ -611,8 +627,8 @@
             "url": "https://{s}.api.tomtom.com/map/1/tile/{variant}/{style}/{z}/{x}/{y}.{ext}?key={apikey}",
             "variant": "basic",
             "max_zoom": 22,
-            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2023 TomTom.</a> ",
-            "attribution": "(C) 1992 - 2023 TomTom.",
+            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2024 TomTom.</a> ",
+            "attribution": "(C) 1992 - 2024 TomTom.",
             "subdomains": "abcd",
             "style": "main",
             "ext": "png",
@@ -623,8 +639,8 @@
             "url": "https://{s}.api.tomtom.com/map/1/tile/{variant}/{style}/{z}/{x}/{y}.{ext}?key={apikey}",
             "variant": "hybrid",
             "max_zoom": 22,
-            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2023 TomTom.</a> ",
-            "attribution": "(C) 1992 - 2023 TomTom.",
+            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2024 TomTom.</a> ",
+            "attribution": "(C) 1992 - 2024 TomTom.",
             "subdomains": "abcd",
             "style": "main",
             "ext": "png",
@@ -635,8 +651,8 @@
             "url": "https://{s}.api.tomtom.com/map/1/tile/{variant}/{style}/{z}/{x}/{y}.{ext}?key={apikey}",
             "variant": "labels",
             "max_zoom": 22,
-            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2023 TomTom.</a> ",
-            "attribution": "(C) 1992 - 2023 TomTom.",
+            "html_attribution": "<a href=\"https://tomtom.com\" target=\"_blank\">&copy;  1992 - 2024 TomTom.</a> ",
+            "attribution": "(C) 1992 - 2024 TomTom.",
             "subdomains": "abcd",
             "style": "main",
             "ext": "png",
@@ -701,7 +717,7 @@
         },
         "OceanBasemap": {
             "url": "https://server.arcgisonline.com/ArcGIS/rest/services/{variant}/MapServer/tile/{z}/{y}/{x}",
-            "variant": "Ocean_Basemap",
+            "variant": "Ocean/World_Ocean_Base",
             "html_attribution": "Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri",
             "attribution": "Tiles (C) Esri -- Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri",
             "max_zoom": 13,
@@ -839,8 +855,8 @@
     "HERE": {
         "normalDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -856,8 +872,8 @@
         },
         "normalDayCustom": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -873,8 +889,8 @@
         },
         "normalDayGrey": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -890,8 +906,8 @@
         },
         "normalDayMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -907,8 +923,8 @@
         },
         "normalDayGreyMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -924,8 +940,8 @@
         },
         "normalDayTransit": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -941,8 +957,8 @@
         },
         "normalDayTransitMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -958,8 +974,8 @@
         },
         "normalDayTraffic": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -975,8 +991,8 @@
         },
         "normalNight": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -992,8 +1008,8 @@
         },
         "normalNightMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1009,8 +1025,8 @@
         },
         "normalNightGrey": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1026,8 +1042,8 @@
         },
         "normalNightGreyMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1043,8 +1059,8 @@
         },
         "normalNightTransit": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1060,8 +1076,8 @@
         },
         "normalNightTransitMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1077,8 +1093,8 @@
         },
         "reducedDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1094,8 +1110,8 @@
         },
         "reducedNight": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1111,8 +1127,8 @@
         },
         "basicMap": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1128,8 +1144,8 @@
         },
         "mapLabels": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1145,8 +1161,8 @@
         },
         "trafficFlow": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1162,8 +1178,8 @@
         },
         "carnavDayGrey": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1179,8 +1195,8 @@
         },
         "hybridDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1196,8 +1212,8 @@
         },
         "hybridDayMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1213,8 +1229,8 @@
         },
         "hybridDayTransit": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1230,8 +1246,8 @@
         },
         "hybridDayGrey": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1247,8 +1263,8 @@
         },
         "hybridDayTraffic": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1264,8 +1280,8 @@
         },
         "pedestrianDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1281,8 +1297,8 @@
         },
         "pedestrianNight": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1298,8 +1314,8 @@
         },
         "satelliteDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1315,8 +1331,8 @@
         },
         "terrainDay": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1332,8 +1348,8 @@
         },
         "terrainDayMobile": {
             "url": "https://{s}.{base}.maps.api.here.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "app_id": "<insert your app_id here>",
@@ -1351,8 +1367,8 @@
     "HEREv3": {
         "normalDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1367,8 +1383,8 @@
         },
         "normalDayCustom": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1383,8 +1399,8 @@
         },
         "normalDayGrey": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1399,8 +1415,8 @@
         },
         "normalDayMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1415,8 +1431,8 @@
         },
         "normalDayGreyMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1431,8 +1447,8 @@
         },
         "normalDayTransit": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1447,8 +1463,8 @@
         },
         "normalDayTransitMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1463,8 +1479,8 @@
         },
         "normalNight": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1479,8 +1495,8 @@
         },
         "normalNightMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1495,8 +1511,8 @@
         },
         "normalNightGrey": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1511,8 +1527,8 @@
         },
         "normalNightGreyMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1527,8 +1543,8 @@
         },
         "normalNightTransit": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1543,8 +1559,8 @@
         },
         "normalNightTransitMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1559,8 +1575,8 @@
         },
         "reducedDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1575,8 +1591,8 @@
         },
         "reducedNight": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1591,8 +1607,8 @@
         },
         "basicMap": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1607,8 +1623,8 @@
         },
         "mapLabels": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1623,8 +1639,8 @@
         },
         "trafficFlow": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1639,8 +1655,8 @@
         },
         "carnavDayGrey": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1655,8 +1671,8 @@
         },
         "hybridDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1671,8 +1687,8 @@
         },
         "hybridDayMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1687,8 +1703,8 @@
         },
         "hybridDayTransit": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1703,8 +1719,8 @@
         },
         "hybridDayGrey": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1719,8 +1735,8 @@
         },
         "pedestrianDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1735,8 +1751,8 @@
         },
         "pedestrianNight": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1751,8 +1767,8 @@
         },
         "satelliteDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1767,8 +1783,8 @@
         },
         "terrainDay": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1783,8 +1799,8 @@
         },
         "terrainDayMobile": {
             "url": "https://{s}.{base}.maps.ls.hereapi.com/maptile/2.1/{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?apiKey={apiKey}&lg={language}",
-            "html_attribution": "Map &copy; 1987-2023 <a href=\"http://developer.here.com\">HERE</a>",
-            "attribution": "Map (C) 1987-2023 HERE",
+            "html_attribution": "Map &copy; 1987-2024 <a href=\"http://developer.here.com\">HERE</a>",
+            "attribution": "Map (C) 1987-2024 HERE",
             "subdomains": "1234",
             "mapID": "newest",
             "apiKey": "<insert your apiKey here>",
@@ -1935,17 +1951,10 @@
     },
     "BasemapAT": {
         "basemap": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 20,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "normal",
             "format": "png",
             "bounds": [
@@ -1962,17 +1971,10 @@
             "name": "BasemapAT.basemap"
         },
         "grau": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 19,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "normal",
             "format": "png",
             "bounds": [
@@ -1989,17 +1991,10 @@
             "name": "BasemapAT.grau"
         },
         "overlay": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 19,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "normal",
             "format": "png",
             "bounds": [
@@ -2016,17 +2011,10 @@
             "name": "BasemapAT.overlay"
         },
         "terrain": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 19,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "grau",
             "format": "jpeg",
             "bounds": [
@@ -2043,17 +2031,10 @@
             "name": "BasemapAT.terrain"
         },
         "surface": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 19,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "grau",
             "format": "jpeg",
             "bounds": [
@@ -2070,17 +2051,10 @@
             "name": "BasemapAT.surface"
         },
         "highdpi": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 19,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "normal",
             "format": "jpeg",
             "bounds": [
@@ -2097,17 +2071,10 @@
             "name": "BasemapAT.highdpi"
         },
         "orthofoto": {
-            "url": "https://maps{s}.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
+            "url": "https://mapsneu.wien.gv.at/basemap/{variant}/{type}/google3857/{z}/{y}/{x}.{format}",
             "max_zoom": 20,
             "html_attribution": "Datenquelle: <a href=\"https://www.basemap.at\">basemap.at</a>",
             "attribution": "Datenquelle: basemap.at",
-            "subdomains": [
-                "",
-                "1",
-                "2",
-                "3",
-                "4"
-            ],
             "type": "normal",
             "format": "jpeg",
             "bounds": [
@@ -2381,23 +2348,139 @@
         }
     },
     "NLS": {
-        "url": "https://nls-{s}.tileserver.com/nls/{z}/{x}/{y}.jpg",
-        "html_attribution": "<a href=\"http://geo.nls.uk/maps/\">National Library of Scotland Historic Maps</a>",
-        "attribution": "National Library of Scotland Historic Maps",
-        "bounds": [
-            [
-                49.6,
-                -12
+        "osgb63k1885": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
             ],
-            [
-                61.7,
-                3
-            ]
-        ],
-        "min_zoom": 1,
-        "max_zoom": 18,
-        "subdomains": "0123",
-        "name": "NLS"
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb63k1885",
+            "name": "NLS.osgb63k1885"
+        },
+        "osgb1888": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb1888",
+            "name": "NLS.osgb1888"
+        },
+        "osgb10k1888": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb10k1888",
+            "name": "NLS.osgb10k1888"
+        },
+        "osgb1919": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb1919",
+            "name": "NLS.osgb1919"
+        },
+        "osgb25k1937": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb25k1937",
+            "name": "NLS.osgb25k1937"
+        },
+        "osgb63k1955": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-osgb63k1955",
+            "name": "NLS.osgb63k1955"
+        },
+        "oslondon1k1893": {
+            "url": "https://api.maptiler.com/tiles/{variant}/{z}/{x}/{y}.jpg?key={apikey}",
+            "html_attribution": "<a href=\"http://maps.nls.uk/projects/subscription-api\">National Library of Scotland Historic Maps</a>",
+            "attribution": "National Library of Scotland Historic Maps",
+            "bounds": [
+                [
+                    49.6,
+                    -12
+                ],
+                [
+                    61.7,
+                    3
+                ]
+            ],
+            "min_zoom": 1,
+            "max_zoom": 18,
+            "variant": "uk-oslondon1k1893",
+            "name": "NLS.oslondon1k1893"
+        }
     },
     "JusticeMap": {
         "income": {
@@ -2957,9 +3040,27 @@
             "name": "SwissFederalGeoportal.SWISSIMAGE"
         }
     },
+    "TopPlusOpen": {
+        "Color": {
+            "url": "http://sgx.geodatenzentrum.de/wmts_topplus_open/tile/1.0.0/{variant}/default/WEBMERCATOR/{z}/{y}/{x}.png",
+            "max_zoom": 18,
+            "html_attribution": "Map data: &copy; <a href=\"http://www.govdata.de/dl-de/by-2-0\">dl-de/by-2-0</a>",
+            "attribution": "Map data: (C) dl-de/by-2-0",
+            "variant": "web",
+            "name": "TopPlusOpen.Color"
+        },
+        "Grey": {
+            "url": "http://sgx.geodatenzentrum.de/wmts_topplus_open/tile/1.0.0/{variant}/default/WEBMERCATOR/{z}/{y}/{x}.png",
+            "max_zoom": 18,
+            "html_attribution": "Map data: &copy; <a href=\"http://www.govdata.de/dl-de/by-2-0\">dl-de/by-2-0</a>",
+            "attribution": "Map data: (C) dl-de/by-2-0",
+            "variant": "web_grau",
+            "name": "TopPlusOpen.Grey"
+        }
+    },
     "_meta": {
         "description": "JSON representation of the leaflet providers defined by the leaflet-providers.js extension to Leaflet (https://github.com/leaflet-extras/leaflet-providers)",
-        "date_of_creation": "2023-01-01",
-        "commit": "commit 90e8260198b4bafd53f0c94c24c6b03c201e8e6c (Bump eslint from 8.29.0 to 8.30.0\n\nBumps [eslint](https://github.com/eslint/eslint) from 8.29.0 to 8.30.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v8.29.0...v8.30.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>)"
+        "date_of_creation": "2024-03-15",
+        "commit": "commit d279aa29f9bd10ed303c07b5fbf84699720af2a4 (Bump eslint from 8.56.0 to 8.57.0\n\nBumps [eslint](https://github.com/eslint/eslint) from 8.56.0 to 8.57.0.\n- [Release notes](https://github.com/eslint/eslint/releases)\n- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/eslint/eslint/compare/v8.56.0...v8.57.0)\n\n---\nupdated-dependencies:\n- dependency-name: eslint\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>)"
     }
 }

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -98,7 +98,7 @@ function geturl(provider::AbstractProvider, x::Integer, y::Integer, z::Integer)
 end
 
 function _access(d)
-    for key in (:apikey, :apiKey, :accessToken, :subscriptionKey, :app_code)
+    for key in (:apikey, :apiKey, :accessToken, :subscriptionKey, :app_code, :key)
         if hasproperty(d, key)
             return key
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ using Dates
         CyclOSM(),
         Jawg(; accesstoken="some_token"),
         MapBox(; accesstoken="some_token"),
-        MapTiler(; apikey="some_apikey")
+        MapTiler(; apikey="some_apikey"),
         TomTom(; apikey="some_apikey"),
         Esri(),
         OpenWeatherMap(; apikey="some_apikey"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ using Dates
         CyclOSM(),
         Jawg(; accesstoken="some_token"),
         MapBox(; accesstoken="some_token"),
-        MapTiler(),
+        MapTiler(; apikey="some_apikey")
         TomTom(; apikey="some_apikey"),
         Esri(),
         OpenWeatherMap(; apikey="some_apikey"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ using Dates
         CyclOSM(),
         Jawg(; accesstoken="some_token"),
         MapBox(; accesstoken="some_token"),
-        MapTiler(; apikey="some_apikey"),
+        MapTiler(; key="some_apikey"),
         TomTom(; apikey="some_apikey"),
         Esri(),
         OpenWeatherMap(; apikey="some_apikey"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ using Dates
         BasemapAT(),
         nlmaps(),
         NASAGIBS(),
-        NLS(),
+        NLS(; apikey="some_apikey"),
         JusticeMap(),
         GeoportailFrance(; apikey="some_apikey"),
         OneMapSG(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,6 @@ using Dates
         Jawg(; accesstoken="some_token"),
         MapBox(; accesstoken="some_token"),
         MapTiler(),
-        Stamen(),
         TomTom(; apikey="some_apikey"),
         Esri(),
         OpenWeatherMap(; apikey="some_apikey"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ using Dates
         BasemapAT(),
         nlmaps(),
         NASAGIBS(),
-        NLS(; apikey="some_apikey"),
+        #NLS(; apikey="some_apikey"),
         JusticeMap(),
         GeoportailFrance(; apikey="some_apikey"),
         OneMapSG(),


### PR DESCRIPTION
Hello.  This PR includes the current leaflet-providers-parsed.json file from the [xyzservices repository](https://raw.githubusercontent.com/geopandas/xyzservices/main/provider_sources/leaflet-providers-parsed.json).

The present one is quite stale and doesn't cover the migration of Stamen's tiles to Stadia Maps among other changes.

This also addresses https://github.com/JuliaGeo/TileProviders.jl/issues/22